### PR TITLE
chore: Trigger CI for pull requests or push, not both

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,14 @@
 name: main
 on:
-  push:
   pull_request:
+    types: [edited, opened, reopened, synchronize]
     branches:
       - main
+      - v**
+  push:
+    branches:
+      - main
+      - v**
 
 jobs:
   build:


### PR DESCRIPTION
# Description

Triggers CI only for pull requests or push, not both at the same time. This will prevent duplicate CI jobs and prevent CI failures triggered by push on PRs.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
