### PR TITLE
chore: bump ueransim to v3.2.7

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,5 @@
 # Contributing
 
-
 Install snapcraft:
 
 ```bash

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: ueransim
 base: core24
-version: '3.2.6+git'
+version: '3.2.7'
 summary: Open source 5G UE and RAN (gNodeB) implementation.
 description: |
   UERANSIM (pronounced "ju-i ræn sɪm"), is the open source state-of-the-art
@@ -39,7 +39,7 @@ apps:
 parts:
   ueransim:
     source: "https://github.com/aligungr/UERANSIM.git"
-    source-commit: "528061fe10389876da58d3bd15e8cba6d7c152a9"
+    source-tag: "v3.2.7"
     plugin: nil
     build-packages:
       - cmake


### PR DESCRIPTION
# Description

We bump the workload to the latest upstream release of UERANSIM: `v3.2.7`.

## Reference
- https://github.com/aligungr/UERANSIM/releases/tag/v3.2.7

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
